### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
-* @felipebalbi @jerrysxie @tullom @RobertZ2011
+* @OpenDevicePartnership/ec-code-owners
+
+# Any changes in the supply-chain folder needs approval
+# from auditors as it relates to cargo vet
+**/supply-chain @OpenDevicePartnership/crate-auditors


### PR DESCRIPTION
This PR updates the CODEOWNERS file to use the EC code owners team as the default codeowners for the repository.
This hardens the repository against stale permission issues down the line by tying the access to being part of the team rather than being explicitly granted permission to a repository.